### PR TITLE
Adding buddybuild status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Feeds4U
 ===========
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5657914d28898101003ae8ea&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5657914d28898101003ae8ea/build/latest)
 
 RSS reader app written in Swift 2.0, and yes, software design is pretty good here.
 


### PR DESCRIPTION
We really liked Feeds4U and wanted to offer you a free continuous integration system [(buddybuild)](http://buddybuild.com) to make sure that your app always works!

If this sounds like something that may be helpful, setup is really simple and we've already taken most of the steps for you…[here](https://dashboard.buddybuild.com/apps/5657914d28898101003ae8ea/build/latest) are the builds we've completed for Feeds4U so far.

![screen shot 2015-11-26 at 3 44 26 pm](https://cloud.githubusercontent.com/assets/13876667/11431823/afc180d4-9454-11e5-9e4a-5bc2299dedf6.png)

To configure your builds and to to make sure we kick off a new build with every commit you make, simply login [here] (https://dashboard.buddybuild.com).

Finally, if you’d like to know the latest build status of your app directly from your repo page, we offer small status badges - like the one seen on the [flappyswift](https://github.com/fullstackio/FlappySwift) repo.

To help add these, we created this pull request by adding a couple of lines to the readme.

If you have any questions or would like to learn more about buddybuild, feel free to email team@buddybuild.com directly or use the Intercom button on the website.